### PR TITLE
Fix Windows MessageBox not being shown.

### DIFF
--- a/EasyWindowWin32.cpp
+++ b/EasyWindowWin32.cpp
@@ -393,8 +393,13 @@ protected:
 				return 1;
 				break;
 			case WM_PAINT:
-				return 1;
-				break;
+				{
+					PAINTSTRUCT	ps;
+					HDC hdc = BeginPaint( hWnd, &ps );
+					EndPaint( hWnd, &ps );
+					return 1;
+					break;
+				}
 			case WM_NCPAINT:
 				//return 0;
 				break;


### PR DESCRIPTION
Just returning 1 in the case of a WM_PAINT event causes win32 message box not to be shown.
There is 2 solutions : Letting DefWindowProc handle WM_PAINT or calling BeginPaint/EndPaint before returning 1.